### PR TITLE
Support null types

### DIFF
--- a/src/typeWriter/factory.ts
+++ b/src/typeWriter/factory.ts
@@ -11,6 +11,9 @@ import unionTypeGenerator from './union'
 
 export default function factory(type: Type, name?: string) {
   switch (true) {
+    case type.isNull():
+      return simpleTypeGenerator('Null')
+
     case type.isString():
       return simpleTypeGenerator('String')
 


### PR DESCRIPTION
This pull request adds support for nulls in the runtypes output.

I needed this for checking union types which can contain nulls.

Also, in order for ts-morph to actually consider nulls, I needed to pass a custom project to `generate()` like so:

```
import {Project} from "ts-morph";
import {generate as generateRuntypes} from 'runtyping';

const project = new Project({
  compilerOptions: {
    strictNullChecks: true
  },
  // ...
});

const generator = generateRuntypes({
  buildInstructions: [ /* ... */ ],
  project
});
```

Also, @johngeorgewright thanks for the great library :-)