### PR TITLE
feat: reuse type aliases

### DIFF
--- a/src/typeWriter/generateOrReuseType.ts
+++ b/src/typeWriter/generateOrReuseType.ts
@@ -4,11 +4,8 @@ import RuntypeGenerator from './RuntypeGenerator'
 import { Declare } from './symbols'
 
 export default function* generateOrReuseType(type: Type): RuntypeGenerator {
-  let typeName = type.getSymbol()?.getName()
-
-  if (typeName === '__type') {
-    typeName = type.getText()
-  }
+  const typeName =
+    type.getAliasSymbol()?.getName() || type.getSymbol()?.getName()
 
   if (!!typeName && (yield [Declare, typeName])) {
     return

--- a/src/typeWriter/generateOrReuseType.ts
+++ b/src/typeWriter/generateOrReuseType.ts
@@ -4,7 +4,11 @@ import RuntypeGenerator from './RuntypeGenerator'
 import { Declare } from './symbols'
 
 export default function* generateOrReuseType(type: Type): RuntypeGenerator {
-  const typeName = type.getSymbol()?.getName()
+  let typeName = type.getSymbol()?.getName()
+
+  if (typeName === '__type') {
+    typeName = type.getText()
+  }
 
   if (!!typeName && (yield [Declare, typeName])) {
     return

--- a/src/typeWriter/index.ts
+++ b/src/typeWriter/index.ts
@@ -55,7 +55,7 @@ export default function writeRuntype(
         break
 
       case Declare:
-        if (recursive || hasTypeDeclaration(targetFile, item.value[1])) {
+        if (recursive || hasTypeDeclaration(sourceFile, item.value[1])) {
           next = true
           writer = writer.write(item.value[1])
         }

--- a/src/typeWriter/index.ts
+++ b/src/typeWriter/index.ts
@@ -55,7 +55,7 @@ export default function writeRuntype(
         break
 
       case Declare:
-        if (recursive || hasTypeDeclaration(sourceFile, item.value[1])) {
+        if (recursive || hasTypeDeclaration(targetFile, item.value[1])) {
           next = true
           writer = writer.write(item.value[1])
         }

--- a/test/tuple.test.ts
+++ b/test/tuple.test.ts
@@ -9,7 +9,7 @@ test('tuple', async () => {
 
     export type A = Static<typeof A>;
 
-    export const B = Tuple(Tuple(Number, String, Number,), Tuple(Number, String, Number,),);
+    export const B = Tuple(A, A,);
 
     export type B = Static<typeof B>;
     "


### PR DESCRIPTION
Reusing interfaces work just fine, but as @rkok has discovered, type aliases needed some extra work.

See #60