### PR TITLE
Nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -D runtyping
       type: Foo # The type you want to convert to a runtype
 
     - file: json/my-json-schema.json # You can even use JSON schema files!!
-      type: ExampleType
+      type: [ExampleType, AnotherExampleType]
 ```
 
 2. Then run: `npx runtyping`
@@ -35,34 +35,41 @@ npm install -D runtyping
 Basic example:
 
 ```ts
-import {generate} from 'runtyping';
+import { generate } from 'runtyping'
 
 const generator = generate({
   buildInstructions: [
-      {
-        targetFile: `src/runtypes.ts`,
-        sourceTypes: [
-            { file: 'src/types.ts', type: 'Foo' },
-            { file: 'json/my-json-schema.json', type: 'ExampleType' }
-        ]
-      },
-      // Add more as needed
-  ]
-});
+    {
+      targetFile: `src/runtypes.ts`,
+      sourceTypes: [
+        { file: 'src/types.ts', type: 'Foo' },
+        {
+          file: 'json/my-json-schema.json',
+          type: ['ExampleType', 'AnotherExampleType'],
+        },
+      ],
+    },
+    // Add more as needed
+  ],
+})
 
-for await (const file of generator) {
-  console.log(`Writing runtype: ${file.getFilePath()}`);
-  file.saveSync();
-}
+;(async () => {
+  for await (const file of generator) {
+    console.log(`Writing runtype: ${file.getFilePath()}`)
+    await file.save()
+  }
+})()
 ```
 
 You can also pass a custom tsconfig file:
 
 ```ts
 const generator = generate({
-  buildInstructions: [ /* ... */ ],
-  tsConfigFile: '/path/to/tsconfig.json'
-});
+  buildInstructions: [
+    /* ... */
+  ],
+  tsConfigFile: '/path/to/tsconfig.json',
+})
 ```
 
 ...or a custom ts-morph project (for the internal compiler):
@@ -70,18 +77,16 @@ const generator = generate({
 (see [generate.ts](src/generate.ts) for the defaults)
 
 ```ts
-import {Project} from "ts-morph";
+import { Project } from 'ts-morph'
 
 const generator = generate({
-  buildInstructions: [ /* ... */ ],
+  buildInstructions: [
+    /* ... */
+  ],
   project: new Project({
-    compilerOptions: {
-        // Enable this if you need nulls to be considered
-      strictNullChecks: true
-    },
     // ...
-  })
-});
+  }),
+})
 ```
 
 ## Thanks

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -83,6 +83,7 @@ function getProject(options: GenerateOptions) {
   return 'project' in options && options.project
     ? options.project
     : new Project({
+        compilerOptions: { strictNullChecks: true },
         manipulationSettings: {
           indentationText: IndentationText.TwoSpaces,
           newLineKind: NewLineKind.LineFeed,

--- a/src/typeWriter/factory.ts
+++ b/src/typeWriter/factory.ts
@@ -11,6 +11,9 @@ import unionTypeGenerator from './union'
 
 export default function factory(type: Type, name?: string) {
   switch (true) {
+    case type.isNull():
+      return simpleTypeGenerator('Null')
+
     case type.isString():
       return simpleTypeGenerator('String')
 

--- a/src/typeWriter/function.ts
+++ b/src/typeWriter/function.ts
@@ -23,7 +23,7 @@ export default function* functionTypeGenerator(
   for (const param of signature.getParameters()) {
     const paramDec = last(param.getDeclarations())
     yield* generateOrReuseType(paramDec.getType())
-    if (isOptionalParam(paramDec)) {
+    if (!paramDec.getType().isNullable() && isOptionalParam(paramDec)) {
       yield [Write, '.optional()']
     }
     yield [Write, ',']

--- a/src/typeWriter/object.ts
+++ b/src/typeWriter/object.ts
@@ -29,8 +29,10 @@ export default function* objectTypeGenerator(type: Type): RuntypeGenerator {
 
   for (const property of type.getProperties()) {
     yield [Write, `${property.getName()}:`]
-    yield* generateOrReuseType(property.getValueDeclarationOrThrow().getType())
-    if (property.hasFlags(SymbolFlags.Optional)) yield [Write, '.optional()']
+    const propertyType = property.getValueDeclarationOrThrow().getType()
+    yield* generateOrReuseType(propertyType)
+    if (property.hasFlags(SymbolFlags.Optional) && !propertyType.isNullable())
+      yield [Write, '.optional()']
     yield [Write, ',']
   }
 

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -1,3 +1,4 @@
+import { Project, QuoteKind } from 'ts-morph'
 import generateFixture from './generateFixture'
 
 test('function', async () => {
@@ -7,7 +8,7 @@ test('function', async () => {
     ).getText()
   ).toMatchInlineSnapshot(`
     "import { A as _A, B as _B, C as _C, D as _D, E as _E, F as _F } from './function';
-    import { Contract, String, Number, Void, Static, Unknown, AsyncContract } from 'runtypes';
+    import { Contract, String, Number, Void, Static, Undefined, Unknown, AsyncContract } from 'runtypes';
 
     export const A = Contract(String, Number, Void);
 
@@ -17,7 +18,7 @@ test('function', async () => {
 
     export type B = _B;
 
-    export const C = Contract(String, Number.optional(), Unknown);
+    export const C = Contract(String, Number.Or(Undefined), Unknown);
 
     export type C = _C;
 
@@ -32,6 +33,34 @@ test('function', async () => {
     export const F = Contract(Number, String);
 
     export type F = _F;
+    "
+  `)
+})
+
+test('function with non-strict nulls', async () => {
+  expect(
+    (
+      await generateFixture(
+        'function',
+        ['C'],
+        new Project({
+          manipulationSettings: {
+            quoteKind: QuoteKind.Single,
+            usePrefixAndSuffixTextForRename: false,
+            useTrailingCommas: true,
+          },
+
+          skipAddingFilesFromTsConfig: true,
+        })
+      )
+    ).getText()
+  ).toMatchInlineSnapshot(`
+    "import { C as _C } from './function';
+    import { Contract, String, Number, Unknown, Static } from 'runtypes';
+
+    export const C = Contract(String, Number.optional(), Unknown);
+
+    export type C = _C;
     "
   `)
 })

--- a/test/generateFixture.ts
+++ b/test/generateFixture.ts
@@ -1,8 +1,13 @@
 import * as pathHelper from 'path'
 import generate from '../src/generate'
 import { accumulate } from '@johngw/async-iterator'
+import { Project } from 'ts-morph'
 
-export default async function generateFixture(name: string, types: string[]) {
+export default async function generateFixture(
+  name: string,
+  types: string[],
+  project?: Project
+) {
   const [file] = await accumulate(
     generate({
       buildInstructions: [
@@ -16,6 +21,7 @@ export default async function generateFixture(name: string, types: string[]) {
           ],
         },
       ],
+      project,
     })
   )
 

--- a/test/maxItems.test.ts
+++ b/test/maxItems.test.ts
@@ -23,9 +23,9 @@ test('json schema', async () => {
   }
 
   expect(file!.getText()).toMatchInlineSnapshot(`
-"import { Record, Tuple, Dictionary, String, Unknown, Static } from 'runtypes';
+"import { Record, Tuple, Dictionary, String, Unknown, Undefined, Static } from 'runtypes';
 
-export const ExampleSchema = Record({ testArray: Tuple().Or(Tuple(Dictionary(Unknown, String),)).Or(Tuple(Dictionary(Unknown, String), Dictionary(Unknown, String),)).optional(), });
+export const ExampleSchema = Record({ testArray: Tuple().Or(Tuple(Dictionary(Unknown, String),)).Or(Tuple(Dictionary(Unknown, String), Dictionary(Unknown, String),)).Or(Undefined), });
 
 export type ExampleSchema = Static<typeof ExampleSchema>;
 "

--- a/test/minItems.test.ts
+++ b/test/minItems.test.ts
@@ -23,9 +23,9 @@ test('json schema', async () => {
   }
 
   expect(file!.getText()).toMatchInlineSnapshot(`
-"import { Record, Tuple, Dictionary, String, Unknown, Static } from 'runtypes';
+"import { Record, Tuple, Dictionary, String, Unknown, Undefined, Static } from 'runtypes';
 
-export const ExampleSchema = Record({ testArray: Tuple(Dictionary(Unknown, String), Dictionary(Unknown, String), Dictionary(Unknown, String),).optional(), });
+export const ExampleSchema = Record({ testArray: Tuple(Dictionary(Unknown, String), Dictionary(Unknown, String), Dictionary(Unknown, String),).Or(Undefined), });
 
 export type ExampleSchema = Static<typeof ExampleSchema>;
 "

--- a/test/null.test.ts
+++ b/test/null.test.ts
@@ -1,0 +1,56 @@
+import { Project, QuoteKind } from 'ts-morph'
+import generateFixture from './generateFixture'
+
+test('strict nulls', async () => {
+  expect((await generateFixture('null', ['A', 'B', 'C'])).getText())
+    .toMatchInlineSnapshot(`
+    "import { Null, Static, String, Record, Undefined } from 'runtypes';
+
+    export const A = Null;
+
+    export type A = Static<typeof A>;
+
+    export const B = Null.Or(String);
+
+    export type B = Static<typeof B>;
+
+    export const C = Record({ a: Null, b: Null.Or(String), c: Null.Or(String).Or(Undefined), });
+
+    export type C = Static<typeof C>;
+    "
+  `)
+})
+
+test('non-strict nulls', async () => {
+  expect(
+    (
+      await generateFixture(
+        'null',
+        ['A', 'B', 'C'],
+        new Project({
+          manipulationSettings: {
+            quoteKind: QuoteKind.Single,
+            usePrefixAndSuffixTextForRename: false,
+            useTrailingCommas: true,
+          },
+          skipAddingFilesFromTsConfig: true,
+        })
+      )
+    ).getText()
+  ).toMatchInlineSnapshot(`
+    "import { Null, Static, String, Record } from 'runtypes';
+
+    export const A = Null;
+
+    export type A = Static<typeof A>;
+
+    export const B = String;
+
+    export type B = Static<typeof B>;
+
+    export const C = Record({ a: Null, b: String, c: String.optional(), });
+
+    export type C = Static<typeof C>;
+    "
+  `)
+})

--- a/test/null.ts
+++ b/test/null.ts
@@ -1,0 +1,8 @@
+type A = null
+type B = string | null
+
+interface C {
+  a: null
+  b: string | null
+  c?: string | null
+}

--- a/test/optional.test.ts
+++ b/test/optional.test.ts
@@ -3,9 +3,9 @@ import generateFixture from './generateFixture'
 test('optional property', async () => {
   expect((await generateFixture('optional', ['A'])).getText())
     .toMatchInlineSnapshot(`
-    "import { Record, String, Static } from 'runtypes';
+    "import { Record, String, Undefined, Static } from 'runtypes';
 
-    export const A = Record({ foo: String.optional(), });
+    export const A = Record({ foo: String.Or(Undefined), });
 
     export type A = Static<typeof A>;
     "

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -23,9 +23,9 @@ test('json schema', async () => {
   }
 
   expect(file!.getText()).toMatchInlineSnapshot(`
-"import { Record, String, Number, Literal, Static } from 'runtypes';
+"import { Record, String, Number, Undefined, Literal, Static } from 'runtypes';
 
-export const ExampleSchema = Record({ firstName: String, lastName: String, age: Number.optional(), hairColor: Literal(\\"black\\").Or(Literal(\\"brown\\")).Or(Literal(\\"blue\\")).optional(), });
+export const ExampleSchema = Record({ firstName: String, lastName: String, age: Number.Or(Undefined), hairColor: Literal(\\"black\\").Or(Literal(\\"brown\\")).Or(Literal(\\"blue\\")).Or(Undefined), });
 
 export type ExampleSchema = Static<typeof ExampleSchema>;
 "


### PR DESCRIPTION
This a more thorough implementation of #58 adding the `strictNullChecks` flag as a default to the project.

Although the output is generated slightly differently, it should be backwards compatible.

The only difference I found was that we were adding both `.optional()` and `.Or(Undefined)` to optional properties, which
according to the runtypes documentation will produce the same thing. So I've found a way to revert to `.optional()` if the `null` type is not found.

