### PR TITLE
feat: add namespace support

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -28,7 +28,7 @@ import {
 } from './typeWriter/symbols'
 import typeNameFormatter, { TypeNameFormatter } from './typeNameFormatter'
 import { DeclaredType } from './typeWriter/TypeWriter'
-import { find, getRelativeImportPath } from './util'
+import { doInModule, find, findInModule, getRelativeImportPath } from './util'
 
 type GeneratorOptionsBase =
   | {
@@ -222,29 +222,31 @@ export default class Generator {
       writer = writer.write(')')
     }
 
-    this.#targetFile.addVariableStatement({
-      isExported: true,
-      declarationKind: VariableDeclarationKind.Const,
-      declarations: [
-        {
-          name: runTypeName,
-          initializer: writer.toString(),
-        },
-      ],
-    })
-
-    if (exportStaticType) {
-      if (!staticImplementation) {
-        this.#runtypesImports.add('Static')
-        staticImplementation = `Static<typeof ${runTypeName}>`
-      }
-
-      this.#targetFile.addTypeAlias({
+    doInModule(this.#targetFile, runTypeName, (node, name) => {
+      node.addVariableStatement({
         isExported: true,
-        name: typeName,
-        type: staticImplementation,
+        declarationKind: VariableDeclarationKind.Const,
+        declarations: [
+          {
+            name,
+            initializer: writer.toString(),
+          },
+        ],
       })
-    }
+
+      if (exportStaticType) {
+        if (!staticImplementation) {
+          this.#runtypesImports.add('Static')
+          staticImplementation = `Static<typeof ${name}>`
+        }
+
+        node.addTypeAlias({
+          isExported: true,
+          name: typeName.split('.').reduceRight((x) => x),
+          type: staticImplementation,
+        })
+      }
+    })
 
     this.#exports.add(sourceType)
 
@@ -265,12 +267,16 @@ export default class Generator {
 
     if (importTypeDeclaration) return importTypeDeclaration
 
-    const declaration =
-      sourceFile.getInterface(typeName) ||
-      sourceFile.getTypeAlias(typeName) ||
-      sourceFile.getEnum(typeName) ||
-      sourceFile.getFunction(typeName) ||
-      sourceFile.getVariableDeclaration(typeName)
+    const declaration = findInModule(
+      sourceFile,
+      typeName,
+      (node, name) =>
+        node.getInterface(name) ||
+        node.getTypeAlias(name) ||
+        node.getEnum(name) ||
+        node.getFunction(name) ||
+        node.getVariableDeclaration(name)
+    )
 
     if (!declaration)
       throw new Error(

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -2,7 +2,9 @@ import generateFixture from './generateFixture'
 
 test('namespace', async () => {
   expect(
-    (await generateFixture('namespace', ['A.B', 'B.C.D', 'A.C'])).getText()
+    (
+      await generateFixture('namespace', ['A.B', 'B.C.D', 'A.C', 'A.D'])
+    ).getText()
   ).toMatchInlineSnapshot(`
     "import { Record, String, Static, Number, Unknown } from 'runtypes';
 
@@ -14,6 +16,10 @@ test('namespace', async () => {
       export const C = Unknown;
 
       export type C = Static<typeof C>;
+
+      export const D = Record({ E: Number, });
+
+      export type D = Static<typeof D>;
     }
 
     export namespace B {

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -1,0 +1,28 @@
+import generateFixture from './generateFixture'
+
+test('namespace', async () => {
+  expect(
+    (await generateFixture('namespace', ['A.B', 'B.C.D', 'A.C'])).getText()
+  ).toMatchInlineSnapshot(`
+    "import { Record, String, Static, Number, Unknown } from 'runtypes';
+
+    export namespace A {
+      export const B = Record({ C: String, });
+
+      export type B = Static<typeof B>;
+
+      export const C = Unknown;
+
+      export type C = Static<typeof C>;
+    }
+
+    export namespace B {
+      export namespace C {
+        export const D = Number;
+
+        export type D = Static<typeof D>;
+      }
+    }
+    "
+  `)
+})

--- a/test/namespace.ts
+++ b/test/namespace.ts
@@ -1,0 +1,15 @@
+export namespace A {
+  export interface B {
+    C: string
+  }
+}
+
+export namespace B {
+  export namespace C {
+    export type D = number
+  }
+}
+
+export namespace A {
+  export type C = unknown
+}

--- a/test/namespace.ts
+++ b/test/namespace.ts
@@ -12,4 +12,7 @@ export namespace B {
 
 export namespace A {
   export type C = unknown
+  export type D = {
+    E: B.C.D
+  }
 }


### PR DESCRIPTION
I'm working on a thing that involves a large number of types generated using `protobufjs`, which produces `.d.ts` files which make heavy use of namespaces. It'd be very convenient to be able to turn those into Runtypes, and I think this is a semi-elegant way to make that happen.