### PR TITLE
fix: recognize built-in types more reliably

### DIFF
--- a/test/builtin.test.ts
+++ b/test/builtin.test.ts
@@ -1,0 +1,13 @@
+import generateFixture from './generateFixture'
+
+test('builtin', async () => {
+  expect((await generateFixture('builtin', ['A'])).getText())
+    .toMatchInlineSnapshot(`
+    "import { Record, InstanceOf, Static } from 'runtypes';
+
+    export const A = Record({ a: InstanceOf(Uint8Array), });
+
+    export type A = Static<typeof A>;
+    "
+  `)
+})

--- a/test/builtin.ts
+++ b/test/builtin.ts
@@ -1,0 +1,3 @@
+export interface A {
+  a: Uint8Array
+}


### PR DESCRIPTION
As-is, this logic fails to capture built-in types on my system; `require.resolve('typescript')` returns `/home/<redacted>/node_modules/typescript/lib/typescript.js`, while the list of declaring file names for `Uint8Array` is as follows:
```
[
  '/node_modules/typescript/lib/lib.es5.d.ts',
  '/node_modules/typescript/lib/lib.es5.d.ts',
  '/node_modules/typescript/lib/lib.es2015.iterable.d.ts',
  '/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts',
  '/node_modules/typescript/lib/lib.es2016.array.include.d.ts'
]
```

(IDK how elegant this trick is, but at least it's better than the `.includes('typescript/lib')` hack I tried at first.)