### PR TITLE
refactor: narrow simple types

### DIFF
--- a/src/typeWriter/simple.ts
+++ b/src/typeWriter/simple.ts
@@ -1,10 +1,18 @@
 import TypeWriter from './TypeWriter'
 import { Import, Write } from './symbols'
 import * as runtypes from 'runtypes'
+import { PickByValue } from '../util'
 
-export default function* simpleTypeWriter(
-  type: keyof typeof runtypes
-): TypeWriter {
+/**
+ * A runtype is considered "simple" when it is already a Runtype
+ * and not a function that returns a Runtype.
+ *
+ * For example, `Number` & `String` are simple types, but
+ * `Array` and `Record` are not.
+ */
+type SimpleRuntype = keyof PickByValue<typeof runtypes, runtypes.Runtype>
+
+export default function* simpleTypeWriter(type: SimpleRuntype): TypeWriter {
   yield [Import, type]
   yield [Write, type]
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,10 +44,15 @@ export function doInModule<
 export function findInModule<
   T extends (node: StatementedNode, name: string) => any
 >(root: StatementedNode, name: string, fn: T): ReturnType<T> | undefined {
-  const findInModuleInner = (node: StatementedNode, nameParts: string[]): ReturnType<T> | undefined => {
+  const findInModuleInner = (
+    node: StatementedNode,
+    nameParts: string[]
+  ): ReturnType<T> | undefined => {
     if (nameParts.length === 0) return undefined
     if (nameParts.length === 1) return fn(node, nameParts[0])
-    for (const child of node.getModules().filter(x => x.getName() === nameParts[0])) {
+    for (const child of node
+      .getModules()
+      .filter((x) => x.getName() === nameParts[0])) {
       const out = findInModuleInner(child, nameParts.slice(1))
       if (out !== undefined) return out
     }
@@ -55,3 +60,8 @@ export function findInModule<
   }
   return findInModuleInner(root, name.split('.'))
 }
+
+export type PickByValue<T, ValueType> = Pick<
+  T,
+  { [Key in keyof T]-?: T[Key] extends ValueType ? Key : never }[keyof T]
+>


### PR DESCRIPTION
We now narrow the simple type argument to only those that are already runtypes and not functions that return runtypes.