### PR TITLE
fix: using enum identifiers as literals

### DIFF
--- a/packages/generator/src/enum.ts
+++ b/packages/generator/src/enum.ts
@@ -1,0 +1,10 @@
+import { SyntaxKind, Type } from 'ts-morph'
+
+export function getEnumIdentifierNameFromEnumLiteral(enumLiteral: Type) {
+  return enumLiteral
+    .getSymbolOrThrow()
+    .getValueDeclarationOrThrow()
+    .getFirstAncestorByKindOrThrow(SyntaxKind.EnumDeclaration)
+    .getFirstChildByKindOrThrow(SyntaxKind.Identifier)
+    .getText()
+}

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -12,3 +12,4 @@ export {
   propNameRequiresQuotes,
   sortUndefinedFirst,
 } from './util'
+export * as Enum from './enum'

--- a/packages/runtypes/src/RuntypesTypeWriters.ts
+++ b/packages/runtypes/src/RuntypesTypeWriters.ts
@@ -1,23 +1,22 @@
 import {
+  DeclareType,
+  Enum,
+  escapeQuottedPropName,
   getGenerics,
   getTypeName,
-  StaticParameters,
-} from '@runtyping/generator'
-import {
-  DeclareType,
-  escapeQuottedPropName,
   Import,
   ImportFromSource,
   PickByValue,
   propNameRequiresQuotes,
   sortUndefinedFirst,
   Static,
+  StaticParameters,
   TypeWriter,
   TypeWriters,
   Write,
 } from '@runtyping/generator'
 import type * as runtypes from 'runtypes'
-import { SymbolFlags, SyntaxKind, Type } from 'ts-morph'
+import { SymbolFlags, Type } from 'ts-morph'
 
 export default class RuntypesTypeWriters extends TypeWriters {
   override *defaultStaticImplementation(): TypeWriter {
@@ -81,14 +80,7 @@ export default class RuntypesTypeWriters extends TypeWriters {
   }
 
   override *enumLiteral(type: Type): TypeWriter {
-    const enumTypeName = getTypeName(
-      type
-        .getSymbolOrThrow()
-        .getValueDeclarationOrThrow()
-        .getFirstAncestorByKindOrThrow(SyntaxKind.EnumDeclaration)
-        .getType()
-    )
-
+    const enumTypeName = Enum.getEnumIdentifierNameFromEnumLiteral(type)
     yield [ImportFromSource, { name: enumTypeName, alias: `_${enumTypeName}` }]
     yield* this.#literal(`_${enumTypeName}.${getTypeName(type)}`)
   }

--- a/packages/runtypes/test/__snapshots__/typewriters.test.ts.snap
+++ b/packages/runtypes/test/__snapshots__/typewriters.test.ts.snap
@@ -72,8 +72,8 @@ export type HorseType = Static<typeof HorseType>;
 `;
 
 exports[`enum 1`] = `
-"import { A as _A, B as _B, C as _C } from '../fixtures/enum';
-import { Static, Guard, Literal } from 'runtypes';
+"import { A as _A, B as _B, C as _C, E as _E } from '../fixtures/enum';
+import { Static, Guard, Literal, String } from 'runtypes';
 
 export const A = Guard((x: any): x is _A => Object.values(_A).includes(x));
 
@@ -86,6 +86,14 @@ export type B = Static<typeof B>;
 export const D = Literal(_C.A3).Or(Literal(_C.B3));
 
 export type D = Static<typeof D>;
+
+export const F = String.Or(Literal(_E.S));
+
+export type F = Static<typeof F>;
+
+export const G = Literal(_C.A3).Or(Literal(_C.B3)).Or(Literal(_C.C3)).Or(Literal(_E.S));
+
+export type G = Static<typeof G>;
 "
 `;
 

--- a/packages/test-type-writers/fixtures/enum.ts
+++ b/packages/test-type-writers/fixtures/enum.ts
@@ -16,3 +16,11 @@ export enum C {
 }
 
 export type D = C.A3 | C.B3
+
+export enum E {
+  S,
+}
+
+export type F = string | E
+
+export type G = C | E

--- a/packages/test-type-writers/src/tests/enum.ts
+++ b/packages/test-type-writers/src/tests/enum.ts
@@ -4,7 +4,9 @@ import { TypeWriterTestProps } from '../types'
 export default function enumTest(props: TypeWriterTestProps) {
   test('enum', async () => {
     expect(
-      (await generateFixture('enum', ['A', 'B', 'D'], props)).getText()
+      (
+        await generateFixture('enum', ['A', 'B', 'D', 'F', 'G'], props)
+      ).getText()
     ).toMatchSnapshot()
   })
 }

--- a/packages/zod/src/ZodTypeWriters.ts
+++ b/packages/zod/src/ZodTypeWriters.ts
@@ -1,5 +1,6 @@
 import {
   DeclareType,
+  Enum,
   escapeQuottedPropName,
   getGenerics,
   getTypeName,
@@ -14,7 +15,7 @@ import {
   Write,
 } from '@runtyping/generator'
 import { titleCase } from 'title-case'
-import { SymbolFlags, SyntaxKind, Type } from 'ts-morph'
+import { SymbolFlags, Type } from 'ts-morph'
 import * as zod from 'zod'
 
 export default class ZodTypeWriters extends TypeWriters {
@@ -51,14 +52,7 @@ export default class ZodTypeWriters extends TypeWriters {
   }
 
   override *enumLiteral(type: Type): TypeWriter {
-    const enumTypeName = getTypeName(
-      type
-        .getSymbolOrThrow()
-        .getValueDeclarationOrThrow()
-        .getFirstAncestorByKindOrThrow(SyntaxKind.EnumDeclaration)
-        .getType()
-    )
-
+    const enumTypeName = Enum.getEnumIdentifierNameFromEnumLiteral(type)
     yield [ImportFromSource, { name: enumTypeName, alias: `_${enumTypeName}` }]
     yield* this.#literal(`_${enumTypeName}.${getTypeName(type)}`)
   }

--- a/packages/zod/test/__snapshots__/typewriters.test.ts.snap
+++ b/packages/zod/test/__snapshots__/typewriters.test.ts.snap
@@ -72,8 +72,8 @@ export type HorseType = Infer<typeof HorseType>;
 `;
 
 exports[`enum 1`] = `
-"import { A as _A, B as _B, C as _C } from '../fixtures/enum';
-import { infer as Infer, nativeEnum, literal } from 'zod';
+"import { A as _A, B as _B, C as _C, E as _E } from '../fixtures/enum';
+import { infer as Infer, nativeEnum, literal, string } from 'zod';
 
 export const A = nativeEnum(_A);
 
@@ -86,6 +86,14 @@ export type B = Infer<typeof B>;
 export const D = literal(_C.A3).or(literal(_C.B3));
 
 export type D = Infer<typeof D>;
+
+export const F = string().or(literal(_E.S));
+
+export type F = Infer<typeof F>;
+
+export const G = literal(_C.A3).or(literal(_C.B3)).or(literal(_C.C3)).or(literal(_E.S));
+
+export type G = Infer<typeof G>;
 "
 `;
 


### PR DESCRIPTION
Using enum identifiers as literals was currently broken. IE:

```typescript
enum MyEnum {
  A,
  B
}

// The following would cause unexpected behaviour
type ReferencingAnEnum = MyEnum
```

Fixes #205