### PR TITLE
fix: unused imports

### DIFF
--- a/packages/generator/src/Generator.ts
+++ b/packages/generator/src/Generator.ts
@@ -199,7 +199,7 @@ export default class Generator {
     }
 
     const canDeclareStatics = (type: Type) =>
-      type.getText() === typeDeclaration.getType().getText()
+      exportStaticType && type.getText() === typeDeclaration.getType().getText()
 
     const runTypeWriter = (typeWriter: TypeWriter) => {
       IteratorHandler.create(typeWriter)

--- a/packages/io-ts/package.json
+++ b/packages/io-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtyping/io-ts",
-  "version": "1.1.0",
+  "version": "0.0.0",
   "description": "Generate io-ts from static types & JSON schema.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/runtypes/package.json
+++ b/packages/runtypes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtyping/runtypes",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "description": "Generate runtypes from static types & JSON schema.",
   "main": "dist/index.js",
   "bin": {

--- a/packages/test-type-writers/src/fixture.ts
+++ b/packages/test-type-writers/src/fixture.ts
@@ -54,9 +54,14 @@ async function getDataNames(testName: string): Promise<string[]> {
         : name
     )
   }
-  return $getDataNames(
-    await import(pathHelper.join(fixturesDataDir, `${testName}.ts`))
-  )
+  try {
+    return $getDataNames(
+      await import(pathHelper.join(fixturesDataDir, `${testName}.ts`))
+    )
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
 }
 
 async function generate(

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtyping/zod",
-  "version": "1.1.0",
+  "version": "0.0.0",
   "description": "Generate zod from static types & JSON schema.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/zod/src/ZodTypeWriters.ts
+++ b/packages/zod/src/ZodTypeWriters.ts
@@ -225,7 +225,8 @@ export default class ZodTypeWriters extends TypeWriters {
 
   override *variadicTuple(type: Type): TypeWriter {
     yield [Import, { source: this.#module, name: 'array' }]
-    yield [Static, [type, yield* this.getStaticReference(type)]]
+    if (yield [CanDeclareStatics, type])
+      yield [Static, [type, yield* this.getStaticReference(type)]]
     yield* this.#array(this.#simple('any'))
     yield [
       Write,


### PR DESCRIPTION
If a variadic tuple is used in a nested type, it can sometimes cause an
unused source import.